### PR TITLE
feat: allow writing the acestream cache into ram

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ instances.
 
 ## Docker Compose
 
+### Standard Mode (Disk Cache)
+
 1. **Start the Container**: Use `docker-compose` to start the container:
 
    ```bash
@@ -71,6 +73,52 @@ instances.
    ```bash
    docker-compose pull && docker-compose up -d
     ```
+
+### RAM Cache Mode (Linux/WSL2 Only)
+
+For improved performance and reduced disk wear, you can run Acestream with cache stored in RAM instead of disk.
+
+**Requirements:**
+- Linux host or WSL2 (does not work on Docker Desktop for Windows without WSL2)
+- At least 8GB of available RAM
+
+**Usage:**
+
+1. **Start in RAM cache mode:**
+
+   ```bash
+   docker-compose --profile ram up -d
+   ```
+
+2. **Switch from standard mode to RAM mode:**
+
+   ```bash
+   docker-compose down
+   docker-compose --profile ram up -d
+   ```
+
+3. **Switch back to standard mode:**
+
+   ```bash
+   docker-compose down
+   docker-compose up -d
+   ```
+
+**Monitor RAM usage:**
+
+```bash
+# Check current RAM usage
+docker exec -it acestream-ram df -h | grep ACEStream
+
+# Real-time monitoring
+watch -n 1 "docker exec -it acestream-ram df -h /root/.ACEStream/.acestream_cache"
+```
+
+**Important Notes:**
+- Only one mode (standard or RAM) can run at a time due to port conflicts
+- Cache data is lost when the container stops (this is expected behavior for RAM cache)
+- RAM cache significantly reduces disk writes, extending SSD lifespan
+- The RAM cache size is set to 8GB by default
 
 ## Accessing the Web Interface
 
@@ -124,6 +172,7 @@ This ensures that the web interface points to the correct Acestream engine insta
 - Hardened startup script (`entrypoint.sh`) that validates environment variables and outputs detailed diagnostics.
 - Automatic patch of `player.html` so the web UI always points to the correct IP and port.
 - Multi-instance support: launch several containers simultaneously without port clashes.
+- **RAM cache mode**: optional profile to store cache in RAM for improved performance and reduced disk wear (Linux/WSL2).
 - Offline builds thanks to the bundled `resources/acestream.tar.gz` archive (no external downloads required).
 - Built-in **port conflict detection**: if the default port `6878` is already occupied (e.g. by the desktop Acestream Player), the Windows setup script automatically picks the next free even port.
 - Optional `--auto-clean` flag: after pulling a newer image the script can safely delete outdated Acestream container images to keep your Docker host tidy.

--- a/README_es.md
+++ b/README_es.md
@@ -63,6 +63,8 @@ instancias.
 
 ## Docker Compose
 
+### Modo Estándar (Caché en Disco)
+
 1. **Iniciar el Contenedor**: Usa `docker-compose` para iniciar el contenedor:
 
    ```bash
@@ -74,6 +76,52 @@ instancias.
    ```bash
    docker-compose pull && docker-compose up -d
     ```
+
+### Modo Caché RAM (Solo Linux/WSL2)
+
+Para mejorar el rendimiento y reducir el desgaste del disco, puedes ejecutar Acestream con la caché almacenada en RAM en lugar del disco.
+
+**Requisitos:**
+- Sistema Linux o WSL2 (no funciona en Docker Desktop para Windows sin WSL2)
+- Al menos 8GB de RAM disponible
+
+**Uso:**
+
+1. **Iniciar en modo caché RAM:**
+
+   ```bash
+   docker-compose --profile ram up -d
+   ```
+
+2. **Cambiar del modo estándar al modo RAM:**
+
+   ```bash
+   docker-compose down
+   docker-compose --profile ram up -d
+   ```
+
+3. **Volver al modo estándar:**
+
+   ```bash
+   docker-compose down
+   docker-compose up -d
+   ```
+
+**Monitorizar el uso de RAM:**
+
+```bash
+# Verificar uso actual de RAM
+docker exec -it acestream-ram df -h | grep ACEStream
+
+# Monitorización en tiempo real
+watch -n 1 "docker exec -it acestream-ram df -h /root/.ACEStream/.acestream_cache"
+```
+
+**Notas Importantes:**
+- Solo puede ejecutarse un modo (estándar o RAM) a la vez debido a conflictos de puerto
+- Los datos de caché se pierden cuando el contenedor se detiene (este es el comportamiento esperado para caché RAM)
+- La caché RAM reduce significativamente las escrituras en disco, prolongando la vida útil de SSDs
+- El tamaño de la caché RAM está configurado en 8GB por defecto
 
 ## Acceder a la Interfaz Web
 
@@ -127,6 +175,7 @@ inicio del contenedor. Esto asegura que la interfaz web apunte a la instancia co
 - Script de arranque reforzado (`entrypoint.sh`) que valida variables de entorno y muestra diagnósticos detallados.
 - Parche automático de `player.html` para que la interfaz web siempre apunte a la IP y puerto correctos.
 - Soporte multi-instancia: puedes lanzar varios contenedores simultáneamente sin conflictos de puertos.
+- **Modo caché RAM**: perfil opcional para almacenar la caché en RAM, mejorando el rendimiento y reduciendo el desgaste del disco (Linux/WSL2).
 - Construcciones offline gracias al archivo `resources/acestream.tar.gz` incluido (no se requieren descargas externas).
 - **Detección automática de conflictos de puertos**: si el puerto por defecto `6878` está ocupado (por ejemplo, por Acestream Player de escritorio), el script de Windows asigna el siguiente puerto par libre.
 - Flag opcional `--auto-clean`: tras descargar una nueva imagen, el script puede eliminar de forma segura las imágenes antiguas de Acestream para mantener limpio tu host Docker.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   acestream:
     image: smarquezp/docker-acestream-ubuntu-home:latest
     container_name: acestream
-    profiles: ["default"]
     ports:
       - 6878:6878
     environment:


### PR DESCRIPTION
Permite mantener el funcionamiento del contenedor hasta la fecha u optar por cargar la caché de acestream en ram

* ```docker compose --profile default up -d```
Genera el contenedor de nombre acestream que sigue escribiendo la caché en el disco.

* ```docker compose --profile ram up -d```
Genera el contenedor de nombre acestream-ram que escribe la caché en ram, ahorrándose escritura inútil en el disco. Requiere linux (quizás funciona con wsl2).

El uso de ram se puede consultar mediante ```docker exec -it acestream-ram df -h | grep ACEStream```.

También se puede monitorizar en tiempo real con
```sudo watch -n 1 "docker exec -it acestream-ram df -h /root/.ACEStream/.acestream_cache"```

Si te gusta la idea tocará actualizar los readmes un poco.