### PR TITLE
Add health check to Docker container

### DIFF
--- a/SetupAcestream.bat
+++ b/SetupAcestream.bat
@@ -121,7 +121,7 @@ echo Creating or updating the docker-compose.yml file...
     echo       - HTTP_PORT=!HTTP_PORT!
     echo       - HTTPS_PORT=!HTTPS_PORT!
     echo     healthcheck:
-    echo       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:!HTTP_PORT!/webui/api/service?method=get_version', timeout=5^)"]
+    echo       test: ["CMD", "sh", "-c", "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:$$HTTP_PORT/webui/api/service?method=get_version', timeout=5^)\""]
     echo       interval: 30s
     echo       timeout: 10s
     echo       retries: 3

--- a/SetupAcestream_es.bat
+++ b/SetupAcestream_es.bat
@@ -122,7 +122,7 @@ echo Creando o actualizando el archivo docker-compose.yml...
     echo       - HTTP_PORT=!HTTP_PORT!
     echo       - HTTPS_PORT=!HTTPS_PORT!
     echo     healthcheck:
-    echo       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:!HTTP_PORT!/webui/api/service?method=get_version', timeout=5^)"]
+    echo       test: ["CMD", "sh", "-c", "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:$$HTTP_PORT/webui/api/service?method=get_version', timeout=5^)\""]
     echo       interval: 30s
     echo       timeout: 10s
     echo       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - HTTP_PORT=6878
       - HTTPS_PORT=6879
     healthcheck:
-      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:${HTTP_PORT}/webui/api/service?method=get_version', timeout=5)"]
+      test: ["CMD", "sh", "-c", "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:$$HTTP_PORT/webui/api/service?method=get_version', timeout=5)\""]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Fixes #10 - Healthcheck was failing with ConnectionRefusedError because Docker Compose does not expand environment variables within CMD arrays. The ${HTTP_PORT} variable was being passed literally to Python instead of being expanded to the actual port number.

Solution: Wrap the healthcheck command in 'sh -c' to enable proper shell variable expansion at runtime. Changed from direct Python invocation to shell-wrapped command that expands $$HTTP_PORT (which becomes $HTTP_PORT in the container and then expands to 6878).

Changes:
- docker-compose.yml: Updated healthcheck test to use sh -c wrapper
- SetupAcestream.bat: Updated generated healthcheck to use sh -c
- SetupAcestream_es.bat: Updated generated healthcheck to use sh -c

This ensures the healthcheck properly connects to the Acestream API endpoint regardless of the configured HTTP_PORT value.